### PR TITLE
Add language switch with RTL layout fix

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -22,7 +22,11 @@ export const ChatInput = ({
   const topics = t.topics
 
   return (
-    <div className="absolute bottom-0 right-0 border-t left-64 bg-gray-900/80 backdrop-blur-sm border-orange-500/10">
+    <div
+      className={`absolute bottom-0 border-t bg-gray-900/80 backdrop-blur-sm border-orange-500/10 ${
+        language === 'ar' ? 'left-0 right-64' : 'right-0 left-64'
+      }`}
+    >
       <div className="w-full max-w-3xl px-4 py-3 mx-auto">
         <div className="flex items-center gap-2 mb-2">
           <button

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -49,17 +49,65 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
   },
 }));
 
+const LanguageSwitch = styled(Switch)(({ theme }) => ({
+  width: 62,
+  height: 34,
+  padding: 7,
+  '& .MuiSwitch-switchBase': {
+    margin: 1,
+    padding: 0,
+    transform: 'translateX(6px)',
+    '&.Mui-checked': {
+      color: '#fff',
+      transform: 'translateX(22px)',
+      '& .MuiSwitch-thumb:before': {
+        backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="12" y="16" text-anchor="middle" font-size="12" font-family="Arial" fill="${encodeURIComponent('#fff')}">AR</text></svg>')`,
+      },
+      '& + .MuiSwitch-track': {
+        opacity: 1,
+        backgroundColor: '#aab4be',
+        ...(theme.applyStyles && theme.applyStyles('dark', { backgroundColor: '#8796A5' })),
+      },
+    },
+  },
+  '& .MuiSwitch-thumb': {
+    backgroundColor: '#001e3c',
+    width: 32,
+    height: 32,
+    '&::before': {
+      content: "''",
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      left: 0,
+      top: 0,
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'center',
+      backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="12" y="16" text-anchor="middle" font-size="12" font-family="Arial" fill="${encodeURIComponent('#fff')}">EN</text></svg>')`,
+    },
+    ...(theme.applyStyles && theme.applyStyles('dark', { backgroundColor: '#003892' })),
+  },
+  '& .MuiSwitch-track': {
+    opacity: 1,
+    backgroundColor: '#aab4be',
+    borderRadius: 20 / 2,
+    ...(theme.applyStyles && theme.applyStyles('dark', { backgroundColor: '#8796A5' })),
+  },
+}));
+
 export function TopBar() {
   const { language, setLanguage, theme, setTheme } = useAppState()
 
   return (
-    <div className="fixed top-0 right-0 z-20 flex items-center gap-4 p-4">
-      <button
-        onClick={() => setLanguage(language === 'en' ? 'ar' : 'en')}
-        className="px-2 py-1 text-sm font-medium text-white bg-gray-700 rounded"
-      >
-        {language === 'en' ? 'AR' : 'EN'}
-      </button>
+    <div
+      className={`fixed top-0 z-20 flex items-center gap-4 p-4 ${
+        language === 'ar' ? 'left-0' : 'right-0'
+      }`}
+    >
+      <LanguageSwitch
+        checked={language === 'ar'}
+        onChange={() => setLanguage(language === 'en' ? 'ar' : 'en')}
+      />
       <MaterialUISwitch
         checked={theme === 'dark'}
         onChange={() => setTheme(theme === 'dark' ? 'light' : 'dark')}


### PR DESCRIPTION
## Summary
- create a styled `LanguageSwitch` using MUI `Switch`
- swap top bar position based on current language
- offset chat input relative to sidebar for RTL

## Testing
- `npm run build` *(fails: `vinxi: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68668090ff94832785a835b0c34629a4