### PR TITLE
Refine theme to red and black

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -23,7 +23,7 @@ export const ChatInput = ({
 
   return (
     <div
-      className={`absolute bottom-0 border-t bg-gray-900/80 backdrop-blur-sm border-orange-500/10 ${
+      className={`absolute bottom-0 border-t bg-black/80 backdrop-blur-sm border-red-600/10 ${
         language === 'ar' ? 'left-0 right-64' : 'right-0 left-64'
       }`}
     >
@@ -31,7 +31,7 @@ export const ChatInput = ({
         <div className="flex items-center gap-2 mb-2">
           <button
             type="button"
-            className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-orange-500 to-red-600 hover:opacity-90 focus:outline-none"
+            className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-red-600 to-red-600 hover:opacity-90 focus:outline-none"
             onClick={() => {
               setInput('')
               setShowTopics(false)
@@ -42,13 +42,13 @@ export const ChatInput = ({
           <div className="relative">
             <button
               type="button"
-              className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-orange-500 to-red-600 hover:opacity-90 focus:outline-none"
+              className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-red-600 to-red-600 hover:opacity-90 focus:outline-none"
               onClick={() => setShowTopics((s) => !s)}
             >
               {t.chooseTopic}
             </button>
             {showTopics && (
-              <div className="absolute z-10 flex flex-col w-32 p-2 mt-1 space-y-1 bg-gray-800 rounded-lg shadow-lg">
+              <div className="absolute z-10 flex flex-col w-32 p-2 mt-1 space-y-1 bg-black rounded-lg shadow-lg">
                 {topics.map((t) => (
                   <button
                     key={t}
@@ -57,7 +57,7 @@ export const ChatInput = ({
                       setInput(t)
                       setShowTopics(false)
                     }}
-                    className={`px-2 py-1 text-sm ${language === 'ar' ? 'text-right' : 'text-left'} text-white rounded hover:bg-gray-700`}
+                    className={`px-2 py-1 text-sm ${language === 'ar' ? 'text-right' : 'text-left'} text-white rounded hover:bg-black`}
 
                   >
                     {t}
@@ -80,7 +80,7 @@ export const ChatInput = ({
               }}
               placeholder={t.placeholder}
 
-              className="w-full py-3 pl-4 pr-12 overflow-hidden text-sm text-white placeholder-gray-400 border rounded-lg shadow-lg resize-none border-orange-500/20 bg-gray-800/50 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-transparent"
+              className="w-full py-3 pl-4 pr-12 overflow-hidden text-sm text-white placeholder-gray-400 border rounded-lg shadow-lg resize-none border-red-600/20 bg-black/50 focus:outline-none focus:ring-2 focus:ring-red-600/50 focus:border-transparent"
               rows={1}
               style={{ minHeight: '44px', maxHeight: '200px' }}
               onInput={(e) => {
@@ -92,7 +92,7 @@ export const ChatInput = ({
             <button
               type="submit"
               disabled={!input.trim() || isLoading}
-              className="absolute p-2 text-orange-500 transition-colors -translate-y-1/2 right-2 top-1/2 hover:text-orange-400 disabled:text-gray-500 focus:outline-none"
+              className="absolute p-2 text-red-600 transition-colors -translate-y-1/2 right-2 top-1/2 hover:text-red-400 disabled:text-gray-500 focus:outline-none"
             >
               <Send className="w-4 h-4" />
             </button>

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -8,17 +8,17 @@ export const ChatMessage = ({ message }: { message: Message }) => (
   <div
     className={`py-6 ${
       message.role === 'assistant'
-        ? 'bg-gradient-to-r from-orange-500/5 to-red-600/5'
+        ? 'bg-gradient-to-r from-red-600/5 to-red-600/5'
         : 'bg-transparent'
     }`}
   >
     <div className="flex items-start w-full max-w-3xl gap-4 mx-auto">
       {message.role === 'assistant' ? (
-        <div className="flex items-center justify-center flex-shrink-0 w-8 h-8 ml-4 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-orange-500 to-red-600">
+        <div className="flex items-center justify-center flex-shrink-0 w-8 h-8 ml-4 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-red-600 to-red-600">
           AI
         </div>
       ) : (
-        <div className="flex items-center justify-center flex-shrink-0 w-8 h-8 text-sm font-medium text-white bg-gray-700 rounded-lg">
+        <div className="flex items-center justify-center flex-shrink-0 w-8 h-8 text-sm font-medium text-white bg-black rounded-lg">
           Y
         </div>
       )}

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,11 +1,11 @@
 export const LoadingIndicator = () => (
-  <div className="px-6 py-6 bg-gradient-to-r from-orange-500/5 to-red-600/5">
+  <div className="px-6 py-6 bg-gradient-to-r from-red-600/5 to-red-600/5">
     <div className="flex items-start w-full max-w-3xl gap-4 mx-auto">
       <div className="relative flex-shrink-0 w-8 h-8">
-        <div className="absolute inset-0 rounded-lg bg-gradient-to-r from-orange-500 via-red-500 to-orange-500 animate-[spin_2s_linear_infinite]"></div>
-        <div className="absolute inset-[2px] rounded-lg bg-gray-900 flex items-center justify-center">
-          <div className="relative flex items-center justify-center w-full h-full rounded-lg bg-gradient-to-r from-orange-500 to-red-600">
-            <div className="absolute inset-0 rounded-lg bg-gradient-to-r from-orange-500 to-red-600 animate-pulse"></div>
+        <div className="absolute inset-0 rounded-lg bg-gradient-to-r from-red-600 to-red-600 to-red-600 animate-[spin_2s_linear_infinite]"></div>
+        <div className="absolute inset-[2px] rounded-lg bg-black flex items-center justify-center">
+          <div className="relative flex items-center justify-center w-full h-full rounded-lg bg-gradient-to-r from-red-600 to-red-600">
+            <div className="absolute inset-0 rounded-lg bg-gradient-to-r from-red-600 to-red-600 animate-pulse"></div>
             <span className="relative z-10 text-sm font-medium text-white">
               AI
             </span>
@@ -18,15 +18,15 @@ export const LoadingIndicator = () => (
         </div>
         <div className="flex gap-2">
           <div
-            className="w-2 h-2 rounded-full bg-orange-500 animate-[bounce_0.8s_infinite]"
+            className="w-2 h-2 rounded-full bg-red-600 animate-[bounce_0.8s_infinite]"
             style={{ animationDelay: '0ms' }}
           ></div>
           <div
-            className="w-2 h-2 rounded-full bg-orange-500 animate-[bounce_0.8s_infinite]"
+            className="w-2 h-2 rounded-full bg-red-600 animate-[bounce_0.8s_infinite]"
             style={{ animationDelay: '200ms' }}
           ></div>
           <div
-            className="w-2 h-2 rounded-full bg-orange-500 animate-[bounce_0.8s_infinite]"
+            className="w-2 h-2 rounded-full bg-red-600 animate-[bounce_0.8s_infinite]"
             style={{ animationDelay: '400ms' }}
           ></div>
         </div>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -31,7 +31,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={(e) => {
       if (e.target === e.currentTarget) handleClose()
     }}>
-      <div className="bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+      <div className="bg-black rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
         <div className="p-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-2xl font-semibold text-white">Settings</h2>
@@ -54,7 +54,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                 </label>
                 <button
                   onClick={() => setIsAddingPrompt(true)}
-                  className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-red-600 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-gradient-to-r from-red-600 to-red-600 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-red-600"
                 >
                   <PlusCircle className="w-4 h-4" />
                   Add Prompt
@@ -62,19 +62,19 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
               </div>
 
               {isAddingPrompt && (
-                <div className="p-3 mb-4 space-y-3 rounded-lg bg-gray-700/50">
+                <div className="p-3 mb-4 space-y-3 rounded-lg bg-black/50">
                   <input
                     type="text"
                     value={promptForm.name}
                     onChange={(e) => setPromptForm(prev => ({ ...prev, name: e.target.value }))}
                     placeholder="Prompt name..."
-                    className="w-full px-3 py-2 text-sm text-white bg-gray-700 border border-gray-600 rounded-lg focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+                    className="w-full px-3 py-2 text-sm text-white bg-black border border-red-600 rounded-lg focus:border-red-600 focus:ring-1 focus:ring-red-600"
                   />
                   <textarea
                     value={promptForm.content}
                     onChange={(e) => setPromptForm(prev => ({ ...prev, content: e.target.value }))}
                     placeholder="Enter prompt content..."
-                    className="w-full h-32 px-3 py-2 text-sm text-white bg-gray-700 border border-gray-600 rounded-lg focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
+                    className="w-full h-32 px-3 py-2 text-sm text-white bg-black border border-red-600 rounded-lg focus:border-red-600 focus:ring-1 focus:ring-red-600"
                   />
                   <div className="flex justify-end gap-2">
                     <button
@@ -85,7 +85,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                     </button>
                     <button
                       onClick={handleAddPrompt}
-                      className="px-3 py-1.5 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-red-600 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-orange-500"
+                      className="px-3 py-1.5 text-sm font-medium text-white bg-gradient-to-r from-red-600 to-red-600 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-red-600"
                     >
                       Save Prompt
                     </button>
@@ -95,7 +95,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
 
               <div className="space-y-2">
                 {prompts.map((prompt) => (
-                  <div key={prompt.id} className="flex items-center justify-between p-3 rounded-lg bg-gray-700/50">
+                  <div key={prompt.id} className="flex items-center justify-between p-3 rounded-lg bg-black/50">
                     <div className="flex-1 min-w-0 mr-4">
                       <h4 className="text-sm font-medium text-white truncate">{prompt.name}</h4>
                       <p className="text-xs text-gray-400 truncate">{prompt.content}</p>
@@ -108,7 +108,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                           checked={prompt.is_active}
                           onChange={() => setPromptActive(prompt.id, !prompt.is_active)}
                         />
-                        <div className="w-11 h-6 bg-gray-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-orange-500"></div>
+                        <div className="w-11 h-6 bg-black peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-red-600 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-600"></div>
                       </label>
                       <button
                         onClick={() => deletePrompt(prompt.id)}
@@ -136,7 +136,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
             </button>
             <button
               onClick={handleClose}
-              className="px-4 py-2 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-orange-500 to-red-600 hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-orange-500"
+              className="px-4 py-2 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-red-600 to-red-600 hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-red-600"
             >
               Close
             </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,11 +31,11 @@ export const Sidebar = ({
   const t = translations[language]
 
   return (
-  <div className="flex flex-col w-64 bg-gray-800 border-r border-gray-700">
-    <div className="flex items-center justify-between p-4 border-b border-gray-700">
+  <div className="flex flex-col w-64 bg-black border-r border-red-600">
+    <div className="flex items-center justify-between p-4 border-b border-red-600">
       <button
         onClick={handleNewChat}
-        className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-orange-500 to-red-600 hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-orange-500"
+        className="flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-red-600 to-red-600 hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-red-600"
       >
         <PlusCircle className="w-4 h-4" />
         {t.newChat}
@@ -47,8 +47,8 @@ export const Sidebar = ({
       {conversations.map((chat) => (
         <div
           key={chat.id}
-          className={`group flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-700/50 ${
-            chat.id === currentConversationId ? 'bg-gray-700/50' : ''
+          className={`group flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-black/50 ${
+            chat.id === currentConversationId ? 'bg-black/50' : ''
           }`}
           onClick={() => setCurrentConversationId(chat.id)}
         >

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -15,7 +15,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
       color: '#fff',
       transform: 'translateX(22px)',
       '& .MuiSwitch-thumb:before': {
-        backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent('#fff')}" d="M4.2 2.5l-.7 1.8-1.8.7 1.8.7.7 1.8.6-1.8L6.7 5l-1.9-.7-.6-1.8zm15 8.3a6.7 6.7 0 11-6.6-6.6 5.8 5.8 0 006.6 6.6z"/></svg>')`,
+        backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path stroke="${encodeURIComponent('#000')}" stroke-width="1" fill="${encodeURIComponent('#fff')}" d="M4.2 2.5l-.7 1.8-1.8.7 1.8.7.7 1.8.6-1.8L6.7 5l-1.9-.7-.6-1.8zm15 8.3a6.7 6.7 0 11-6.6-6.6 5.8 5.8 0 006.6 6.6z"/></svg>')`,
       },
       '& + .MuiSwitch-track': {
         opacity: 1,
@@ -37,7 +37,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
       top: 0,
       backgroundRepeat: 'no-repeat',
       backgroundPosition: 'center',
-      backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent('#fff')}" d="M9.305 1.667V3.75h1.389V1.667h-1.39zm-4.707 1.95l-.982.982L5.09 6.072l.982-.982-1.473-1.473zm10.802 0L13.927 5.09l.982.982 1.473-1.473-.982-.982zM10 5.139a4.872 4.872 0 00-4.862 4.86A4.872 4.872 0 0010 14.862 4.872 4.872 0 0014.86 10 4.872 4.872 0 0010 5.139zm0 1.389A3.462 3.462 0 0113.471 10a3.462 3.462 0 01-3.473 3.472A3.462 3.462 0 016.527 10 3.462 3.462 0 0110 6.528zM1.665 9.305v1.39h2.083v-1.39H1.666zm14.583 0v1.39h2.084v-1.39h-2.084zM5.09 13.928L3.616 15.4l.982.982 1.473-1.473-.982-.982zm9.82 0l-.982.982 1.473 1.473.982-.982-1.473-1.473zM9.305 16.25v2.083h1.389V16.25h-1.39z"/></svg>')`,
+      backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path stroke="${encodeURIComponent('#000')}" stroke-width="1" fill="${encodeURIComponent('#fff')}" d="M9.305 1.667V3.75h1.389V1.667h-1.39zm-4.707 1.95l-.982.982L5.09 6.072l.982-.982-1.473-1.473zm10.802 0L13.927 5.09l.982.982 1.473-1.473-.982-.982zM10 5.139a4.872 4.872 0 00-4.862 4.86A4.872 4.872 0 0010 14.862 4.872 4.872 0 0014.86 10 4.872 4.872 0 0010 5.139zm0 1.389A3.462 3.462 0 0113.471 10a3.462 3.462 0 01-3.473 3.472A3.462 3.462 0 016.527 10 3.462 3.462 0 0110 6.528zM1.665 9.305v1.39h2.083v-1.39H1.666zm14.583 0v1.39h2.084v-1.39h-2.084zM5.09 13.928L3.616 15.4l.982.982 1.473-1.473-.982-.982zm9.82 0l-.982.982 1.473 1.473.982-.982-1.473-1.473zM9.305 16.25v2.083h1.389V16.25h-1.39z"/></svg>')`,
     },
     ...(theme.applyStyles && theme.applyStyles('dark', { backgroundColor: '#003892' })),
   },
@@ -61,7 +61,7 @@ const LanguageSwitch = styled(Switch)(({ theme }) => ({
       color: '#fff',
       transform: 'translateX(22px)',
       '& .MuiSwitch-thumb:before': {
-        backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="12" y="16" text-anchor="middle" font-size="12" font-family="Arial" fill="${encodeURIComponent('#fff')}">AR</text></svg>')`,
+        backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="12" y="16" text-anchor="middle" font-size="12" font-family="Arial" fill="${encodeURIComponent('#fff')}" stroke="${encodeURIComponent('#000')}" stroke-width="0.5">AR</text></svg>')`,
       },
       '& + .MuiSwitch-track': {
         opacity: 1,
@@ -83,7 +83,7 @@ const LanguageSwitch = styled(Switch)(({ theme }) => ({
       top: 0,
       backgroundRepeat: 'no-repeat',
       backgroundPosition: 'center',
-      backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="12" y="16" text-anchor="middle" font-size="12" font-family="Arial" fill="${encodeURIComponent('#fff')}">EN</text></svg>')`,
+      backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="12" y="16" text-anchor="middle" font-size="12" font-family="Arial" fill="${encodeURIComponent('#fff')}" stroke="${encodeURIComponent('#000')}" stroke-width="0.5">EN</text></svg>')`,
     },
     ...(theme.applyStyles && theme.applyStyles('dark', { backgroundColor: '#003892' })),
   },

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -25,7 +25,7 @@ export const WelcomeScreen = ({
   return (
     <div className="flex items-center justify-center flex-1 px-4">
       <div className="w-full max-w-3xl mx-auto text-center">
-      <h1 className="mb-4 text-6xl font-bold text-transparent uppercase bg-gradient-to-r from-orange-500 to-red-600 bg-clip-text">
+      <h1 className="mb-4 text-6xl font-bold text-transparent uppercase bg-gradient-to-r from-red-600 to-red-600 bg-clip-text">
         <span className="text-white">TanStack</span> Chat
       </h1>
       <p className="w-2/3 mx-auto mb-6 text-lg text-gray-400">
@@ -34,7 +34,7 @@ export const WelcomeScreen = ({
       <div className="flex items-center justify-center gap-2 mb-4">
         <button
           type="button"
-          className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-orange-500 to-red-600 hover:opacity-90 focus:outline-none"
+          className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-red-600 to-red-600 hover:opacity-90 focus:outline-none"
           onClick={() => {
             setInput('')
             setShowTopics(false)
@@ -46,13 +46,13 @@ export const WelcomeScreen = ({
         <div className="relative">
           <button
             type="button"
-            className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-orange-500 to-red-600 hover:opacity-90 focus:outline-none"
+            className="px-3 py-1.5 text-sm font-medium text-white rounded-lg bg-gradient-to-r from-red-600 to-red-600 hover:opacity-90 focus:outline-none"
             onClick={() => setShowTopics((s) => !s)}
           >
             {t.chooseTopic}
           </button>
           {showTopics && (
-            <div className="absolute z-10 flex flex-col w-32 p-2 mt-1 space-y-1 bg-gray-800 rounded-lg shadow-lg">
+            <div className="absolute z-10 flex flex-col w-32 p-2 mt-1 space-y-1 bg-black rounded-lg shadow-lg">
               {topics.map((t) => (
                 <button
                   key={t}
@@ -61,7 +61,7 @@ export const WelcomeScreen = ({
                     setInput(t)
                     setShowTopics(false)
                   }}
-                  className={`px-2 py-1 text-sm ${language === 'ar' ? 'text-right' : 'text-left'} text-white rounded hover:bg-gray-700`}
+                  className={`px-2 py-1 text-sm ${language === 'ar' ? 'text-right' : 'text-left'} text-white rounded hover:bg-black`}
 
                 >
                   {t}
@@ -83,14 +83,14 @@ export const WelcomeScreen = ({
               }
             }}
             placeholder={t.placeholder}
-            className="w-full py-3 pl-4 pr-12 overflow-hidden text-sm text-white placeholder-gray-400 border rounded-lg resize-none border-orange-500/20 bg-gray-800/50 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-transparent"
+            className="w-full py-3 pl-4 pr-12 overflow-hidden text-sm text-white placeholder-gray-400 border rounded-lg resize-none border-red-600/20 bg-black/50 focus:outline-none focus:ring-2 focus:ring-red-600/50 focus:border-transparent"
             rows={1}
             style={{ minHeight: '88px' }}
           />
           <button
             type="submit"
             disabled={!input.trim() || isLoading}
-            className="absolute p-2 text-orange-500 transition-colors -translate-y-1/2 right-2 top-1/2 hover:text-orange-400 disabled:text-gray-500 focus:outline-none"
+            className="absolute p-2 text-red-600 transition-colors -translate-y-1/2 right-2 top-1/2 hover:text-red-400 disabled:text-gray-500 focus:outline-none"
           >
             <Send className="w-4 h-4" />
           </button>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,7 +4,6 @@ import {
   HeadContent,
   Scripts,
 } from '@tanstack/react-router'
-import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { ConvexClientProvider } from '../convex'
 
 import appCss from '../styles.css?url'
@@ -34,7 +33,6 @@ export const Route = createRootRoute({
   component: () => (
     <RootDocument>
       <Outlet />
-      <TanStackRouterDevtools />
     </RootDocument>
   ),
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -250,7 +250,7 @@ function Home() {
   }, [updateConversationTitle]);
 
   return (
-    <div className={`relative flex h-screen ${theme === 'dark' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-900'}`}> 
+    <div className="relative flex h-screen bg-black text-white">
       <TopBar />
 
 
@@ -271,7 +271,7 @@ function Home() {
       {/* Main Content */}
       <div className="flex flex-col flex-1">
         {error && (
-          <p className="w-full max-w-3xl p-4 mx-auto font-bold text-orange-500">{error}</p>
+          <p className="w-full max-w-3xl p-4 mx-auto font-bold text-red-600">{error}</p>
         )}
         {currentConversationId ? (
           <>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,11 @@
 @import "tailwindcss";
 @import "highlight.js/styles/github-dark.css";
 
+.to-red-600 {
+    --tw-gradient-to: oklch(0.65 0.3 29.03);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-from-position), oklch(0.54 0.25 28.35) var(--tw-gradient-from-position), oklch(0.63 0.29 28.98) var(--tw-gradient-to-position));
+}
+
 body {
   @apply m-0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
@@ -90,27 +95,27 @@ html {
 }
 
 .prose blockquote {
-  border-left-color: #f97316; /* orange-500 */
-  background-color: rgba(249, 115, 22, 0.1);
+  border-left-color: #dc2626; /* red-600 */
+  background-color: rgba(220, 38, 38, 0.1);
   padding: 1em;
   margin: 1.25em 0;
   border-radius: 0.5rem;
 }
 
 .prose hr {
-  border-color: rgba(249, 115, 22, 0.2);
+  border-color: rgba(220, 38, 38, 0.2);
   margin: 2em 0;
 }
 
 .prose a {
-  color: #f97316; /* orange-500 */
+  color: #dc2626; /* red-600 */
   text-decoration: underline;
   text-decoration-thickness: 0.1em;
   text-underline-offset: 0.2em;
 }
 
 .prose a:hover {
-  color: #fb923c; /* orange-400 */
+  color: #dc2626; /* red-600 */
 }
 
 .prose table {
@@ -121,11 +126,11 @@ html {
 
 .prose th, .prose td {
   padding: 0.75em;
-  border: 1px solid rgba(249, 115, 22, 0.2);
+  border: 1px solid rgba(220, 38, 38, 0.2);
 }
 
 .prose th {
-  background-color: rgba(249, 115, 22, 0.1);
+  background-color: rgba(220, 38, 38, 0.1);
   font-weight: 600;
 }
 
@@ -187,12 +192,12 @@ html {
 
 .prose th,
 .prose td {
-  border: 1px solid rgba(249, 115, 22, 0.2);
+  border: 1px solid rgba(220, 38, 38, 0.2);
   padding: 0.5em;
 }
 
 .prose th {
-  background-color: rgba(249, 115, 22, 0.1);
+  background-color: rgba(220, 38, 38, 0.1);
 }
 
 .prose strong {
@@ -205,7 +210,7 @@ html {
 }
 
 .prose blockquote {
-  border-left: 4px solid #f97316; /* orange-500 */
+  border-left: 4px solid #dc2626; /* red-600 */
   padding-left: 1em;
   margin: 1em 0;
   color: #d1d5db; /* text-gray-300 */


### PR DESCRIPTION
## Summary
- apply consistent red button styling
- darken backgrounds to black
- add stroke to language/theme icons
- remove TanStackRouterDevtools
- tweak prose color styles and add custom red class

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68669f687cbc8327b4d8b9b706cbfbea