### PR TITLE
Fix Sentry replay causing DOM append error

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,9 +1,9 @@
-import * as Sentry from '@sentry/react';
+import * as Sentry from "@sentry/react";
 
 export function initSentry() {
   // Skip Sentry initialization if DSN is not defined
   if (!import.meta.env.VITE_SENTRY_DSN) {
-    console.log('Sentry DSN not found. Skipping Sentry initialization.');
+    console.log("Sentry DSN not found. Skipping Sentry initialization.");
     return;
   }
 
@@ -11,16 +11,16 @@ export function initSentry() {
     dsn: import.meta.env.VITE_SENTRY_DSN,
     integrations: [
       Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration({
-        maskAllText: false,
-        blockAllMedia: false,
-      }),
+      // Sentry's Replay integration currently
+      // causes a HierarchyRequestError when hydrating the
+      // full HTML document. Disable it for now.
+      // Sentry.replayIntegration({
+      //   maskAllText: false,
+      //   blockAllMedia: false,
+      // }),
     ],
     // Performance Monitoring
     tracesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
-    // Session Replay
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
     environment: import.meta.env.MODE,
   });
 }


### PR DESCRIPTION
## Summary
- disable Sentry Replay integration

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866b72b72d08327bb138f462f192a23