### PR TITLE
Fix hydration errors

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -17,4 +17,5 @@ const AppComponent = process.env.SENTRY_DSN
     })
   : StartClient
 
-hydrateRoot(document, <AppComponent router={router} />)
+const container = document.getElementById('root') ?? document
+hydrateRoot(container, <AppComponent router={router} />)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -31,24 +31,12 @@ export const Route = createRootRoute({
   }),
 
   component: () => (
-    <RootDocument>
-      <Outlet />
-    </RootDocument>
+    <>
+      <HeadContent />
+      <ConvexClientProvider>
+        <Outlet />
+        <Scripts />
+      </ConvexClientProvider>
+    </>
   ),
 })
-
-function RootDocument({ children }: { children: React.ReactNode }) {
-  return (
-    <html>
-      <head>
-        <HeadContent />
-      </head>
-      <body>
-        <ConvexClientProvider>
-          {children}
-        </ConvexClientProvider>
-        <Scripts />
-      </body>
-    </html>
-  )
-}


### PR DESCRIPTION
## Summary
- adjust hydration container to check for a `root` element before falling back to the document
- simplify root route layout to avoid injecting duplicate `<html>` structure

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866ba3b9d288327b233736f30bf7157