### PR TITLE
Fix 414 error in AI response

### DIFF
--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -50,7 +50,7 @@ const DEFAULT_SYSTEM_PROMPT = `You are TanStack Chat, an AI assistant using Mark
 Keep responses concise and well-structured. Use appropriate Markdown formatting to enhance readability and understanding.`
 
 // Non-streaming implementation
-export const genAIResponse = createServerFn({ method: 'GET', response: 'raw' })
+export const genAIResponse = createServerFn({ method: 'POST', response: 'raw' })
   .validator(
     (d: {
       messages: Array<Message>


### PR DESCRIPTION
## Summary
- change `genAIResponse` to use `POST` request instead of `GET`

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867c52a6eb88327a1e6efc1dfab824c