### PR TITLE
Fix client initialization and type errors

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -10,20 +10,25 @@ initSentry()
 
 const router = createRouter()
 
-// Check if Sentry DSN is defined before creating error boundary
-const AppComponent = process.env.SENTRY_DSN
+// Choose the component wrapper depending on Sentry configuration
+const Root = process.env.SENTRY_DSN
   ? Sentry.withErrorBoundary(StartClient, {
       fallback: () => <div>An error has occurred. Our team has been notified.</div>,
     })
   : StartClient
 
-// Ensure there is a valid DOM element for React to hydrate
-let container = document.getElementById('root') as HTMLElement | null
-
-if (!container) {
-  container = document.createElement('div')
-  container.id = 'root'
-  document.body.appendChild(container)
+export default function Client() {
+  return <Root router={router} />
 }
 
-hydrateRoot(container, <AppComponent router={router} />)
+// Hydrate on the client if we're in the browser
+if (typeof document !== 'undefined') {
+  let container = document.getElementById('root') as HTMLElement | null
+  if (!container) {
+    container = document.createElement('div')
+    container.id = 'root'
+    document.body.appendChild(container)
+  }
+
+  hydrateRoot(container, <Client />)
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { styled } from '@mui/material/styles'
 import Switch from '@mui/material/Switch'
 import { useAppState } from '../store'

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -21,7 +21,7 @@ export interface State {
   conversations: Conversation[]
   currentConversationId: string | null
   isLoading: boolean
-  language: 'ar' | 'ar'
+  language: 'ar' | 'en'
 }
 
 const initialState: State = {


### PR DESCRIPTION
## Summary
- export a default Client component and hydrate it in `client.tsx`
- remove an unused React import in `TopBar`
- correct the language type definition

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867e40e857083279856465be035cb28