### PR TITLE
Improve error handling for AI fetch

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -99,6 +99,12 @@ function Home() {
         },
       })
 
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        const errMsg = data.error || 'Failed to fetch AI response'
+        throw new Error(errMsg)
+      }
+
       const reader = response.body?.getReader()
       if (!reader) {
         throw new Error('No reader found in response')


### PR DESCRIPTION
## Summary
- check the response from `genAIResponse` before streaming
- throw a descriptive error if the request fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867e793e714832799799b41a6aca305