### PR TITLE
Fix streaming event parsing

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -131,7 +131,10 @@ function Home() {
             if (line) {
               try {
                 const json = JSON.parse(line)
-                if (json.type === 'content_block_delta') {
+                if (
+                  json.type === 'content_block_delta' ||
+                  json.type === 'response.output_text.delta'
+                ) {
                   newMessage = {
                     ...newMessage,
                     content: newMessage.content + json.delta.text,


### PR DESCRIPTION
## Summary
- fix the message stream parser to handle `response.output_text.delta` events

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867ead47b2483279f28199ffb1ac2e7