### PR TITLE
Improve responsive layout

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -7,8 +7,9 @@ interface ChatInputProps {
   setInput: (value: string) => void;
   handleSubmit: (e: React.FormEvent) => Promise<void>;
   isLoading: boolean;
-  
+
   disabled?: boolean;
+  sidebarOpen: boolean;
 }
 
 export const ChatInput = ({
@@ -16,16 +17,21 @@ export const ChatInput = ({
   setInput,
   handleSubmit,
   isLoading,
-  disabled = false
+  disabled = false,
+  sidebarOpen
 }: ChatInputProps) => {
   const { language } = useAppState()
   const t = translations[language]
 
+  const offsetClass = sidebarOpen
+    ? language === 'ar'
+      ? 'left-0 md:right-64 right-0'
+      : 'right-0 md:left-64 left-0'
+    : 'left-0 right-0'
+
   return (
     <div
-      className={`absolute bottom-0 border-t text-white backdrop-blur-sm border-red-600/10 ${
-        language === 'ar' ? 'left-0 right-64' : 'right-0 left-64'
-      }`}
+      className={`absolute bottom-0 border-t text-white backdrop-blur-sm border-red-600/10 ${offsetClass}`}
       style={{ background: 'rgba(0,0,0,0.8)' }}
     >
       <div className="w-full max-w-3xl px-4 py-3 mx-auto">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -39,7 +39,7 @@ export const Sidebar = ({
   const t = translations[language]
 
   return (
-  <div className="flex flex-col w-64 text-white border-r shadow-lg" style={{background:'#0d0d0d',borderColor:'#e50914'}}>
+  <div className="flex flex-col w-64 text-white border-r shadow-lg fixed inset-y-0 left-0 z-30 md:static" style={{background:'#0d0d0d',borderColor:'#e50914'}}>
     <div className="flex items-center justify-between p-4 border-b border-red-600">
       <button
         onClick={handleNewChat}

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -33,7 +33,7 @@ export const WelcomeScreen = ({
       <div className="flex justify-center mb-4">
         <BrandLogo className="w-20 h-auto" />
       </div>
-      <p className="w-2/3 mx-auto mb-6 text-lg text-gray-400">
+      <p className="w-full sm:w-2/3 mx-auto mb-6 text-lg text-gray-400">
         {t.welcomeSubtitle}
       </p>
       <div className="flex items-center justify-center gap-2 mb-4">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -51,6 +51,12 @@ function Home() {
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const [pendingMessage, setPendingMessage] = useState<Message | null>(null)
   const [isSidebarOpen, setIsSidebarOpen] = useState(true)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setIsSidebarOpen(window.innerWidth >= 768)
+    }
+  }, [])
   const [error, setError] = useState<string | null>(null);
   const [systemPrompt, setSystemPrompt] = useState<string | null>(null)
   const [inputDisabled, setInputDisabled] = useState(false)
@@ -385,7 +391,7 @@ const processAIResponse = useCallback(async (conversationId: string, userMessage
       ) : (
         <button
           onClick={() => setIsSidebarOpen(true)}
-          className="fixed top-1/2 left-0 z-10 -translate-y-1/2 rounded-r-lg bg-red-600 p-2 text-white"
+          className={`fixed top-1/2 z-10 -translate-y-1/2 bg-red-600 p-2 text-white ${language === 'ar' ? 'right-0 rounded-l-lg' : 'left-0 rounded-r-lg'}`}
         >
           <GoSidebarExpand className="w-5 h-5" />
         </button>
@@ -421,6 +427,7 @@ const processAIResponse = useCallback(async (conversationId: string, userMessage
               handleSubmit={handleSubmit}
               isLoading={isLoading}
               disabled={inputDisabled}
+              sidebarOpen={isSidebarOpen}
             />
           </>
         ) : (


### PR DESCRIPTION
## Summary
- adjust chat input based on sidebar open state
- make sidebar overlay on small screens
- tweak welcome screen text width
- hide sidebar on small screens by default
- mirror sidebar toggle button for RTL

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867f598e51c83278928431a389ffd9c